### PR TITLE
Fix error in package check output: Remove get_all.. alias for read_las_mnemonic()

### DIFF
--- a/R/las_read_mnemonics_df.R
+++ b/R/las_read_mnemonics_df.R
@@ -4,7 +4,7 @@
 #' @param dir The Target Directory containing the .las files (required)
 #' @export
 #' @examples
-#' get_all_las_mnemonics(dir)
+#' read_las_mnemonics_df(".")
 
 
 read_las_mnemonics_df <- function(dir)

--- a/man/read_las_mnemonics_df.Rd
+++ b/man/read_las_mnemonics_df.Rd
@@ -13,5 +13,5 @@ read_las_mnemonics_df(dir)
 This function extracts las mnemonics from all las files in a directory
 }
 \examples{
-get_all_las_mnemonics(dir)
+read_las_mnemonics_df(".")
 }


### PR DESCRIPTION
@Gitmaxwell 

This change fixes an error in reported when running `R CMD check lastools_1.0.0.tar.gz` on a build lastool package or when running `devtools::check()` within R for lastools.     

Error Message:
 ```R
 >checking examples ... ERROR
  Running examples in ‘lastools-Ex.R’ failed
  The error most likely occurred in:
  
  > base::assign(".ptime", proc.time(), pos = "CheckExEnv")
  > ### Name: read_las_mnemonics_df
  > ### Title: Read las curve mnemonics data to data frame
  > ### Aliases: read_las_mnemonics_df
  > 
  > ### ** Examples
  > 
  > get_all_las_mnemonics(dir)
  Error in get_all_las_mnemonics(dir) : 
    could not find function "get_all_las_mnemonics"
  Execution halted
```

The change replaces the get_all_las_mnemonics(dir) alias for the actual name read_las_mnemonics(".") in the @examples tag.   Note, a real directory (".") is used in the example to solve a subsequent error report about 'dir' not being a directory.

Let me know if this change could be accepted (or rejected) or needs some additional changes before merging.

Thanks,

DC
