### PR TITLE
Fix minor import warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,7 +6,8 @@ Version: 1.0.0
 Imports:
     ggplot2,
     stringr,
-    data.table
+    data.table,
+    reshape2
 Author: Matthew Dick & Kane Maxwell
 Maintainer: Matthew Dick <mgmdick@gmail.com>
 Description: Functions for reading and writing version 1.2 and 2.0 LAS files

--- a/R/las_read_data_dtl.R
+++ b/R/las_read_data_dtl.R
@@ -8,7 +8,6 @@
 #'
 
 read_las_data_dtl <- function (dir) {
-  library(data.table)
   laslist <- list.files(dir, pattern = "\\.las$",recursive = TRUE,full.names = T)
   las_data <- lapply(laslist,function(x) try(.get_las_data_dt(x)))
   return(las_data)
@@ -17,7 +16,7 @@ read_las_data_dtl <- function (dir) {
 #function passes info into read_las_data_df
 .get_las_data_dt <- function(x)
 {
-  library(data.table)
+  requireNamespace(data.table)
   las <- lastools::read_las(x)
   filename <- x
 


### PR DESCRIPTION
@Gitmaxwell,

This change fixes a few devtools::check warnings:

Steps to duplicate warning:    
- r
- [r-prompt]>library(devtools)
- [r-prompt]>devtools::check()
...
❯ checking dependencies in R code ... WARNING
  '::' or ':::' import not declared from: ‘reshape2’
  'library' or 'require' call not declared from: ‘data.table’
  'library' or 'require' call to ‘data.table’ in package code.
    Please use :: or requireNamespace() instead.
    See section 'Suggested packages' in the 'Writing R Extensions' manual.
...

The proposed solutions are as follows:
- add reshape2 to the DESCRIPTION imports
- change `library(data.table)` to `requireNamespace(data.table)` since  data.table is already imported in via the DESCRIPTION and NAMESPACE files
- remove one unused instance of library(data.table)

Let me know if this change could be accepted (or rejected) or needs some additional changes before merging.

Thanks,

DC

 