### PR TITLE
Setup basic test infrastructure

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,6 +17,7 @@ Description: Functions for reading and writing version 1.2 and 2.0 LAS files
 License: MIT + file LICENSE
 LazyData: TRUE
 Suggests:
-    knitr
+    knitr,
+    testthat
 VignetteBuilder: knitr
 RoxygenNote: 7.0.1

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,4 @@
+library(testthat)
+library(lastools)
+
+test_check("lastools")

--- a/tests/testthat/test_read_las.R
+++ b/tests/testthat/test_read_las.R
@@ -1,0 +1,7 @@
+library(lastools)
+
+test_that("read extdata/example.las and verify version is '2'", {
+  las = read_las(system.file("extdata", "example.las", package = "lastools"))
+  expect_equal(las$VERSION, 2)
+})
+


### PR DESCRIPTION
@Gitmaxwell,

This pull request sets up basic test infrastructure, as described at :
https://r-pkgs.org/tests.html.

It has one test to check that read_las will read the example.las in extdata and properly parse the version number.  The test passes in my test runs. 

The tests can be run with:
cd lastools
r
[r-prompt]>library(devtools)
[r-prompt]>devtools::test()

Let me know if this change could be accepted (or rejected) or needs some additional changes before merging.

Thanks,

DC