### PR TITLE
fix test for v1.2 sample minimal las file

### DIFF
--- a/R/las_read.R
+++ b/R/las_read.R
@@ -125,7 +125,7 @@ read_las <- function(filepath, replace_null = T) {
   lines <- paste(lines, collapse = "\n")
   lines <- stringr::str_replace_all(lines, "-", " -")
 
-  return(data.table::fread(lines, header = T,showProgress = FALSE))
+  return(data.table::fread(lines, showProgress = FALSE))
   #added showProgress = FALSE to supress warnings - KM 14-Nov-2017
 }
 

--- a/tests/testthat/test_read_las.R
+++ b/tests/testthat/test_read_las.R
@@ -8,6 +8,8 @@ test_that("read extdata/example.las and verify version is '2'", {
 test_that("test read v1.2 sample.las", {
   las = read_las(system.file("extdata", "1.2", "sample.las", package = "lastools"))
   expect_equal(las$VERSION, 1.2)
+  # First item in las$LOG$DEPT should be the same as the ~WELL STRT value.
+  expect_equal(las$LOG$DEPT[1], 1670)
 })
 
 test_that("test read v1.2 sample_curve_api.las has curve api data", {


### PR DESCRIPTION
@Gitmaxwell,

The minimal v1.2 doesn't have header names in the data section.

So the solution is to remove the hard coded 'headers = TRUE'
from data.table::fread(). By default a header line will be created
only if the first data line has all fields of type 'character'. This
solution also works with the v1.2 sample.las which has a header
data row.  An extra test is added to the sample.las test to make sure
this change doesn't break parsing sample.las.

Let me know if this change could be accepted (or rejected) or 
needs some additional changes before merging.

Thanks,

DC