### PR TITLE
Fix v1.2 well section field order in internal representation

### DIFF
--- a/tests/testthat/test_read_las.R
+++ b/tests/testthat/test_read_las.R
@@ -1,24 +1,48 @@
 library(lastools)
 
+#-----------------------------------------------------------------------------
+# LAS v2.0 tests
+#-----------------------------------------------------------------------------
 test_that("read extdata/example.las and verify version is '2'", {
-  las = read_las(system.file("extdata", "example.las", package = "lastools"))
+  las_file <- "example.las"
+  las <- read_las(system.file("extdata", las_file, package = "lastools"))
   expect_equal(las$VERSION, 2)
 })
 
+#-----------------------------------------------------------------------------
+# LAS v1.2 tests
+#-----------------------------------------------------------------------------
 test_that("test read v1.2 sample.las", {
-  las = read_las(system.file("extdata", "1.2", "sample.las", package = "lastools"))
+  las_file <- "sample.las"
+  test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+  las <- read_las(test_path)
   expect_equal(las$VERSION, 1.2)
   # First item in las$LOG$DEPT should be the same as the ~WELL STRT value.
   expect_equal(las$LOG$DEPT[1], 1670)
 })
 
+test_that("test v1.2 sample.las well section values and descs", {
+  las_file <- "sample.las"
+  test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$VERSION, 1.2)
+  # UWI VALUE
+  expect_equal(las$WELL$VALUE[12], "100091604920W300")
+})
+
 test_that("test read v1.2 sample_curve_api.las has curve api data", {
-  las = read_las(system.file("extdata", "1.2", "sample_curve_api.las", package = "lastools"))
+  las_file <- "sample_curve_api.las"
+  test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+
+  las <- read_las(test_path)
   expect_equal(las$CURVE$API.CODE[2], "7 350 02 00")
 })
 
 test_that("test read v1.2 sample_minimal.las log data starts at 635.0000", {
-  las = read_las(system.file("extdata", "1.2", "sample_minimal.las", package = "lastools"))
+  las_file <- "sample_minimal.las"
+  test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+
+  las <- read_las(test_path)
   if (las$LOG$DEPT[1] != 635) {
     print("Value of las$LOG$DEPT[1]: [")
     print(las$LOG$DEPT[1])
@@ -33,23 +57,28 @@ test_that("test read v1.2 sample_minimal.las log data starts at 635.0000", {
 test_that("test read v1.2 sample_wrapped.las", {
   skip(
     "error message:
-    'names' attribute [36] must be the same length as the vector [7]Warning message:
+    'names' attribute [36] must be the same length as the vector [7]
+    Warning message:
     In data.table::fread(lines, header = T, showProgress = FALSE) :
-      Stopped early on line 8. Expected 7 fields but found 1. Consider fill=TRUE and comment.char=. First discarded non-empty line: <<909.875000>>"
+      Stopped early on line 8. Expected 7 fields but found 1.
+      Consider fill=TRUE and comment.char=.
+      First discarded non-empty line: <<909.875000>>"
   )
-  las = read_las(system.file("extdata", "1.2", "sample_wrapped.las", package = "lastools"))
+  las_file <- "sample_wrapped.las"
+  test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+  las <- read_las(test_path)
 })
 
-test_that("test v1.2 sample_inf_uwi_leading_zero value is '05001095820000', a numerical string", {
-  skip("UWI value, las$WELL$VALUE[12] == 'UNIQUE WELL ID'")
-  las = read_las(system.file("extdata", "1.2", "sample_inf_uwi_leading_zero.las", package = "lastools"))
-  # expect_equal(las$LOG$VALUE[12], '05001095820000')
+test_that("test v1.2 sample_inf_uwi_leading_zero value is '05001095820000'", {
+  las_file <- "sample_inf_uwi_leading_zero.las"
+  test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$WELL$VALUE[12], "05001095820000")
 })
 
-test_that("test v1.2 sample_inf_api_leading_zero value is '05001095820000', a numerical string", {
-  skip("API value, las$WELL$VALUE[12] == 'API NUMBER'")
-  las = read_las(system.file("extdata", "1.2", "sample_inf_api_leading_zero.las", package = "lastools"))
-  # expect_equal(las$LOG$VALUE[12], '05001095820000')
-   
+test_that("test v1.2 sample_inf_api_leading_zero value is '05001095820000'", {
+  las_file <- "sample_inf_api_leading_zero.las"
+  test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$WELL$VALUE[12], "05001095820000")
 })
-

--- a/tests/testthat/test_write.R
+++ b/tests/testthat/test_write.R
@@ -1,0 +1,15 @@
+library(lastools)
+
+
+#-----------------------------------------------------------------------------
+# LAS v1.2 tests
+#-----------------------------------------------------------------------------
+test_that("test write v1.2 sample.las", {
+  las_file <- "sample.las"
+  test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+  las <- read_las(test_path)
+  write_las(las, "new_file.las")
+  newlas <- read_las("new_file.las")
+  expect_equal(las$WELL$VALUE[12], newlas$WELL$VALUE[12])
+  unlink("new_file.las")
+})


### PR DESCRIPTION
@Gitmaxwell,

This pull request, fixes a couple of v1.2 las file version tests that check the ~Well sections UWI and API values are strings.

Because many of the v1.2 well section value and description fields are reversed, this change also switches those fields for the lastools internal representation of the data. The STRT, STOP, STEP, and NULL fields are exceptions. They have their value and description fields in the regular order. 

This change also adds a test case for writing the v1.2 las file with  las_write.R code changes to restore the ~Well section value and description fields to the v1.2 las file standard order so that the v1.2 las file that is output meets the v1.2 standard.

This approach has been adopted from the lasio projects approach to this situation.  

There is also some minor style changes changing some '=' to '<-'  in some places.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,

DC