### PR TITLE
Update test_read_las.R for working wrapped_data test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,4 +20,4 @@ Suggests:
     knitr,
     testthat
 VignetteBuilder: knitr
-RoxygenNote: 7.0.1
+RoxygenNote: 7.0.2

--- a/R/las_read.R
+++ b/R/las_read.R
@@ -45,8 +45,9 @@ read_las <- function(filepath, replace_null = T) {
 
   #Convert data_block to a data.frame
   if (wrap) {
-    # If the 
+    # If 'wrap' is true then we need to parse multi-line data rows.
     data_block <- lines[data_block_rows]
+
     # Per spec, the number of ~A data fields must match the
     # number of Curve MNEN fields. We use this value to 
     # split the wrapped data in to the correct number of fields

--- a/R/las_read.R
+++ b/R/las_read.R
@@ -23,6 +23,7 @@ read_las <- function(filepath, replace_null = T) {
   lines <- lines[!is.na(lines)]
   #print(lines[1:30])
   version <- .las_get_version(lines)
+  wrap <- .las_get_wrap(lines)
   well_block_rows <- .las_get_block_dims(lines, "~W")
   curve_block_rows <- .las_get_block_dims(lines, "~C")
   param_block_rows <- .las_get_block_dims(lines, "~P")
@@ -41,8 +42,24 @@ read_las <- function(filepath, replace_null = T) {
   print(curve_block_rows)
   curve_data <- do.call(rbind, lapply(lines[curve_block_rows], function(x) .las_parse_table_line(x, section = "~C")))
   param_data <- do.call(rbind, lapply(lines[param_block_rows], function(x) .las_parse_table_line(x, section = "~P")))
-  #Convert to a data.frame
-  log_data <- data.frame(.las_get_log_data(lines[data_block_rows]))
+
+  #Convert data_block to a data.frame
+  if (wrap) {
+    # If the 
+    data_block <- lines[data_block_rows]
+    # Per spec, the number of ~A data fields must match the
+    # number of Curve MNEN fields. We use this value to 
+    # split the wrapped data in to the correct number of fields
+    # per row.
+    number_of_data_fields <- length(curve_data$MNEM)
+
+    log_data <- data.frame(
+      .las_get_wrapped_log_data(data_block, number_of_data_fields)
+    )
+  } else {
+    log_data <- data.frame(.las_get_log_data(lines[data_block_rows]))
+  }
+
   #Replace null characters if required
   if (replace_null == T) {
     log_data[log_data == as.numeric(as.character(well_data$VALUE[stringr::str_detect(well_data$MNEM, "NULL")]))] <- NA
@@ -65,11 +82,16 @@ read_las <- function(filepath, replace_null = T) {
   return(out)
 }
 
-
 .las_get_version <- function(lines) {
   version_row <- which(stringr::str_detect(lines, "~V"))
   version = lines[version_row+1]
   if (stringr::str_detect(version, "1.2")) return(1.2) else return(2.0)
+}
+
+.las_get_wrap <- function(lines) {
+  version_row <- which(stringr::str_detect(lines, "~V"))
+  wrap = lines[version_row+2]
+  if (stringr::str_detect(wrap, "YES")) return(TRUE) else return(FALSE)
 }
 
 .las_get_block_dims <- function(lines, section) {
@@ -147,4 +169,30 @@ read_las <- function(filepath, replace_null = T) {
 
   return(data.table::fread(lines, showProgress = FALSE))
   #added showProgress = FALSE to supress warnings - KM 14-Nov-2017
+}
+
+.las_get_wrapped_log_data <- function(lines, number_of_data_fields) {
+  # get data without the first line which is the Section header string.
+  data_strs <- lines[2:length(lines)]
+
+  # Join all the wrapped data lines together.
+  # Note: they are character strings of numbers.
+  data_str <- paste(data_strs, sep=" ", collapse=" ")
+
+  # Reduce space delimiters to a single space delimiter per delimit.
+  mydata <- strsplit(data_str, "[[:space:]]+")[[1]]
+
+
+  # Calculate the number of rows based on the number of fields.
+  num_rows = length(mydata)/number_of_data_fields
+  dim(mydata) <- c(number_of_data_fields, num_rows)
+
+  # Build the datastring for sending to data.table.
+  newdatastr = ""
+  for (row_num in 1:num_rows) {
+    tmp <- paste(mydata[,row_num], sep=" ", collapse=" ")
+    newdatastr <- paste0(newdatastr, tmp, sep="\n")
+  }
+
+  return(data.table::fread(newdatastr, showProgress = FALSE, header=FALSE))
 }

--- a/tests/testthat/test_read_las.R
+++ b/tests/testthat/test_read_las.R
@@ -17,7 +17,7 @@ test_that("test read v1.2 sample.las", {
   test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
   las <- read_las(test_path)
   expect_equal(las$VERSION, 1.2)
-  # First item in las$LOG$DEPT should be the same as the ~WELL STRT value.
+  # First value in las$LOG$DEPT should be the same as the ~WELL STRT value.
   expect_equal(las$LOG$DEPT[1], 1670)
 })
 
@@ -55,18 +55,18 @@ test_that("test read v1.2 sample_minimal.las log data starts at 635.0000", {
 })
 
 test_that("test read v1.2 sample_wrapped.las", {
-  skip(
-    "error message:
-    'names' attribute [36] must be the same length as the vector [7]
-    Warning message:
-    In data.table::fread(lines, header = T, showProgress = FALSE) :
-      Stopped early on line 8. Expected 7 fields but found 1.
-      Consider fill=TRUE and comment.char=.
-      First discarded non-empty line: <<909.875000>>"
-  )
   las_file <- "sample_wrapped.las"
   test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
   las <- read_las(test_path)
+
+  expect_equal(las$LOG$DEPT[1], 910.000)
+
+  # las$LOG$DT[1] == -999.25 == this las file's 'NULL' value
+  expect_equal(typeof(las$LOG$DT[1]), "double")
+  expect_true(is.na(las$LOG$DT[1]))
+
+  # Verify the another row starts correctly
+  expect_equal(las$LOG$DEPT[5], 909.5)
 })
 
 test_that("test v1.2 sample_inf_uwi_leading_zero value is '05001095820000'", {


### PR DESCRIPTION
@Gitmaxwell,

This change enables the test for wrapped data to pass.  The change adds a 2 new functions:
.las_get_wrap()
- This gets the wrap flag from the ~Version section.

.las_get_wrapped_log_data()
- This parses and transforms the wrapped data so that it can create the required data string for data.table to read.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,

DC