### PR TITLE
Add initial 2.0 specific tests

### DIFF
--- a/inst/extdata/2.0/sample_2.0.las
+++ b/inst/extdata/2.0/sample_2.0.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/inst/extdata/2.0/sample_2.0_based.las
+++ b/inst/extdata/2.0/sample_2.0_based.las
@@ -1,0 +1,35 @@
+~VERSION INFORMATION
+ VERS.                       2.0    :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                       NO     :   ONE LINE PER TIME STEP
+#
+~WELL INFORMATION 
+STRT    .S      0.0000                           :START TIME 
+STOP    .S      39.9000                          :STOP TIME
+STEP    .S      0.3000                           :STEP
+NULL    .       -999.25                          :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       ANY ET 12-34-12-34               :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5                    :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       100123401234W500                 :UNIQUE WELL ID
+#
+~CURVE INFORMATION
+ ETIM   .S               :  1  ELAPSED TIME
+ BFR1   .OHMM            :  2  SINGLE PROBE 1 RESISTIVITY
+ BSG1   .PSIG            :  3  SINGLE PROBE 1 STRAIN GAUGE PRESSURE 
+#
+~PARAMETER INFORMATION
+MRT    .DEGC            67.0    : BOTTOM HOLE TEMPERATURE
+GDEPT  .M               3456.5  : GAUGE DEPTH
+DFD    .KG/M3           1000.0  : MUD WEIGHT
+#
+~A
+0.0000          0.2125          16564.1445
+0.3000          0.2125          16564.1445
+0.6000          0.2125          16564.2421
+0.9000          0.2125          16564.0434
+1.2000          0.2125          16564.0430
+1.5000          0.2125          16564.0435

--- a/inst/extdata/2.0/sample_2.0_inf_api_leading_zero.las
+++ b/inst/extdata/2.0/sample_2.0_inf_api_leading_zero.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+API     .       05001095820000                   :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/inst/extdata/2.0/sample_2.0_inf_uwi.las
+++ b/inst/extdata/2.0/sample_2.0_inf_uwi.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       300E074350061450                 :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/inst/extdata/2.0/sample_2.0_inf_uwi_leading_zero.las
+++ b/inst/extdata/2.0/sample_2.0_inf_uwi_leading_zero.las
@@ -1,0 +1,47 @@
+~VERSION INFORMATION
+ VERS.                          2.0 :   CWLS LOG ASCII STANDARD -VERSION 2.0
+ WRAP.                          NO  :   ONE LINE PER DEPTH STEP
+~WELL INFORMATION 
+#MNEM.UNIT              DATA                       DESCRIPTION
+#----- -----            ----------               -------------------------
+STRT    .M              1670.0000                :START DEPTH
+STOP    .M              1660.0000                :STOP DEPTH
+STEP    .M              -0.1250                  :STEP 
+NULL    .               -999.25                  :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.             :COMPANY
+WELL    .       AAAAA_2            :WELL
+FLD     .       WILDCAT                          :FIELD
+LOC     .       12-34-12-34W5M                   :LOCATION
+PROV    .       ALBERTA                          :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.         :SERVICE COMPANY
+DATE    .       13-DEC-86                        :LOG DATE
+UWI     .       05001095820000                   :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT              API CODES                   CURVE DESCRIPTION
+#------------------     ------------              -------------------------
+ DEPT   .M                                       :  1  DEPTH
+ DT     .US/M           60 520 32 00             :  2  SONIC TRANSIT TIME
+ RHOB   .K/M3           45 350 01 00             :  3  BULK DENSITY
+ NPHI   .V/V            42 890 00 00             :  4  NEUTRON POROSITY
+ SFLU   .OHMM           07 220 04 00             :  5  SHALLOW RESISTIVITY
+ SFLA   .OHMM           07 222 01 00             :  6  SHALLOW RESISTIVITY
+ ILM    .OHMM           07 120 44 00             :  7  MEDIUM RESISTIVITY
+ ILD    .OHMM           07 120 46 00             :  8  DEEP RESISTIVITY
+~PARAMETER INFORMATION
+#MNEM.UNIT              VALUE             DESCRIPTION
+#--------------     ----------------      -----------------------------------------------
+ MUD    .               GEL CHEM        :   MUD TYPE
+ BHT    .DEGC           35.5000         :   BOTTOM HOLE TEMPERATURE
+ BS     .MM             200.0000        :   BIT SIZE
+ FD     .K/M3           1000.0000       :   FLUID DENSITY
+ MATR   .               SAND            :   NEUTRON MATRIX
+ MDEN   .               2710.0000       :   LOGGING MATRIX DENSITY
+ RMF    .OHMM           0.2160          :   MUD FILTRATE RESISTIVITY
+ DFD    .K/M3           1525.0000       :   DRILL FLUID DENSITY
+~OTHER
+     Note: The logging tools became stuck at 625 metres causing the data 
+     between 625 metres and 615 metres to be invalid.
+~A  DEPTH     DT    RHOB        NPHI   SFLU    SFLA      ILM      ILD
+1670.000   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.875   123.450 2550.000    0.450  123.450  123.450  110.200  105.600
+1669.750   123.450 2550.000    0.450  123.450  123.450  110.200  105.600

--- a/inst/extdata/2.0/sample_2.0_minimal.las
+++ b/inst/extdata/2.0/sample_2.0_minimal.las
@@ -1,0 +1,28 @@
+~V
+VERS.                   2.0   :   CWLS log ASCII Standard -VERSION 2.0
+WRAP.                   NO    :   One line per depth step
+~W
+STRT.M                          635.0000        :START DEPTH
+STOP.M                          400.0000        :STOP DEPTH
+STEP.M                          -0.1250         :STEP 
+NULL.                           -999.25         :NULL VALUE
+COMP.           ANY OIL COMPANY INC.            :COMPANY
+WELL.           ANY ET AL 12-34-12-34           :WELL
+FLD .           WILDCAT                         :FIELD
+LOC .           12-34-12-34W5M                  :LOCATION
+PROV.           ALBERTA                         :PROVINCE 
+SRVC.           ANY LOGGING COMPANY INC.        :SERVICE COMPANY
+DATE.           13-DEC-86                       :LOG DATE
+UWI .           100123401234W500                :UNIQUE WELL ID
+~C
+DEPT    .M                              :   DEPTH
+RHOB    .K/M3                           :   BULK DENSITY
+NPHI    .VOL/VOL                        :   NEUTRON POROSITY - SANDSTONE
+MSFL    .OHMM                           :   Rxo RESISTIVITY
+SFLA    .OHMM                           :   SHALLOW RESISTIVITY
+ILM     .OHMM                           :   MEDIUM RESISTIVITY
+ILD     .OHMM                           :   DEEP RESISTIVITY
+SP      .MV                             :   SPONTANEOUS POTENTIAL
+~A
+ 635.0000     2256.0000   0.4033  22.0781 22.0781 20.3438 3.6660 123.4
+ 634.8750     2256.0000   0.4033  22.0781 22.0781 20.3438 3.6660 123.4

--- a/inst/extdata/2.0/sample_2.0_wrapped.las
+++ b/inst/extdata/2.0/sample_2.0_wrapped.las
@@ -1,0 +1,71 @@
+~VERSION INFORMATION
+ VERS.                 2.0      :   CWLS log ASCII Standard -VERSION 2.0
+ WRAP.                 YES      :   Multiple lines per depth step
+~WELL INFORMATION 
+#MNEM.UNIT                DATA                         DESCRIPTION
+#----- -----           ----------           -----------------------------
+STRT    .M               910.0000               :START DEPTH
+STOP    .M               909.5000               :STOP DEPTH
+STEP    .M               -0.1250                :STEP 
+NULL    .                -999.25                :NULL VALUE
+COMP    .       ANY OIL COMPANY INC.            :COMPANY
+WELL    .       ANY ET AL 12-34-12-34           :WELL
+FLD     .       WILDCAT                         :FIELD
+LOC     .       12-34-12-34W5M                  :LOCATION
+PROV    .       ALBERTA                         :PROVINCE 
+SRVC    .       ANY LOGGING COMPANY INC.        :SERVICE COMPANY
+SON     .       142085                          :SERVICE ORDER NUMBER
+DATE    .       13-DEC-86                       :LOG DATE
+UWI     .       100123401234W500                :UNIQUE WELL ID
+~CURVE INFORMATION
+#MNEM.UNIT                                    Curve Description
+#---------                               ------------------------------
+ DEPT   .M                              :    Depth
+ DT     .US/M                           :  1 Sonic Travel Time
+ RHOB   .K/M                            :  2 Density-Bulk Density
+ NPHI   .V/V                            :  3 Porosity -Neutron
+ RX0    .OHMM                           :  4 Resistivity -Rxo
+ RESS   .OHMM                           :  5 Resistivity -Shallow
+ RESM   .OHMM                           :  6 Resistivity -Medium
+ RESD   .OHMM                           :  7 Resistivity -Deep
+ SP     .MV                             :  8 Spon. Potential
+ GR     .GAPI                           :  9 Gamma Ray
+ CALI   .MM                             : 10 Caliper
+ DRHO   .K/M3                           : 11 Delta-Rho
+ EATT   .DBM                            : 12 EPT Attenuation
+ TPL    .NS/M                           : 13 TP -EPT
+ PEF    .                               : 14 PhotoElectric Factor
+ FFI    .V/V                            : 15 Porosity -NML FFI
+ DCAL   .MM                             : 16 Caliper-Differential
+ RHGF   .K/M3                           : 17 Density-Formation
+ RHGA   .K/M3                           : 18 Density-Apparent
+ SPBL   .MV                             : 19 Baselined SP
+ GRC    .GAPI                           : 20 Gamma Ray BHC
+ PHIA   .V/V                            : 21 Porosity -Apparent
+ PHID   .V/V                            : 22 Porosity -Density
+ PHIE   .V/V                            : 23 Porosity -Effective
+ PHIN   .V/V                            : 24 Porosity -Neut BHC
+ PHIC   .V/V                            : 25 Porosity -Total HCC
+ R0     .OHMM                           : 26 Ro
+ RWA    .OHMM                           : 27 Rfa
+ SW     .                               : 28 Sw -Effective
+ MSI    .                               : 29 Sh Idx -Min
+ BVW    .                               : 30 BVW
+ FGAS   .                               : 31 Flag -Gas Index
+ PIDX   .                               : 32 Prod Idx
+ FBH    .                               : 33 Flag -Bad Hole
+ FHCC   .                               : 34 Flag -HC Correction
+ LSWB   .                               : 35 Flag -Limit SWB
+~A Log data section
+910.000000
+  -999.2500  2692.7075     0.3140    19.4086    19.4086    13.1709    12.2681
+    -1.5010    96.5306   204.7177    30.5822  -999.2500  -999.2500     3.2515
+  -999.2500     4.7177  3025.0264  3025.0264    -1.5010    93.1378     0.1641
+     0.0101     0.1641     0.3140     0.1641    11.1397     0.3304     0.9529
+     0.0000     0.1564     0.0000    11.1397     0.0000     0.0000     0.0000
+909.875000
+  -999.2500  2712.6460     0.2886    23.3987    23.3987    13.6129    12.4744
+    -1.4720    90.2803   203.1093    18.7566  -999.2500  -999.2500     3.7058
+  -999.2500     3.1093  3004.6050  3004.6050    -1.4720    86.9078     0.1456
+    -0.0015     0.1456     0.2886     0.1456    14.1428     0.2646     1.0000
+     0.0000     0.1456     0.0000    14.1428     0.0000     0.0000     0.0000

--- a/tests/testthat/test_read_las.R
+++ b/tests/testthat/test_read_las.R
@@ -1,16 +1,8 @@
 library(lastools)
 
 #-----------------------------------------------------------------------------
-# LAS v2.0 tests
-#-----------------------------------------------------------------------------
-test_that("read extdata/example.las and verify version is '2'", {
-  las_file <- "example.las"
-  las <- read_las(system.file("extdata", las_file, package = "lastools"))
-  expect_equal(las$VERSION, 2)
-})
-
-#-----------------------------------------------------------------------------
 # LAS v1.2 tests
+# Sample .las files in [root]/extdata/1.2/..
 #-----------------------------------------------------------------------------
 test_that("test read v1.2 sample.las", {
   las_file <- "sample.las"
@@ -79,6 +71,78 @@ test_that("test v1.2 sample_inf_uwi_leading_zero value is '05001095820000'", {
 test_that("test v1.2 sample_inf_api_leading_zero value is '05001095820000'", {
   las_file <- "sample_inf_api_leading_zero.las"
   test_path <- system.file("extdata", "1.2", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$WELL$VALUE[12], "05001095820000")
+})
+
+#-----------------------------------------------------------------------------
+# LAS v2.0 tests
+# Sample .las files in [root]/extdata/2.0/..
+#-----------------------------------------------------------------------------
+test_that("read extdata/example.las and verify version is '2'", {
+  las_file <- "example.las"
+  las <- read_las(system.file("extdata", las_file, package = "lastools"))
+  expect_equal(las$VERSION, 2)
+})
+
+test_that("test v2.0 sample.las", {
+  las_file <- "sample_2.0.las"
+  test_path <- system.file("extdata", "2.0", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$VERSION, 2.0)
+  # First value in las$LOG$DEPT should be the same as the ~WELL STRT value.
+  expect_equal(las$LOG$DEPT[1], 1670)
+})
+
+test_that("test v2.0 minimal las file", {
+  las_file <- "sample_2.0_minimal.las"
+  test_path <- system.file("extdata", "2.0", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$VERSION, 2.0)
+  # First value in las$LOG$DEPT should be the same as the ~WELL STRT value.
+  expect_equal(las$LOG$DEPT[1], 635)
+})
+
+test_that("test v2.0 based las file", {
+  las_file <- "sample_2.0_based.las"
+  test_path <- system.file("extdata", "2.0", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$VERSION, 2.0)
+  # First value in las$LOG$DEPT should be the same as the ~WELL STRT value.
+  expect_equal(las$LOG$ETIM[1], 0.0)
+})
+
+test_that("test v2.0 wrapped las file", {
+  las_file <- "sample_2.0_wrapped.las"
+  test_path <- system.file("extdata", "2.0", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$VERSION, 2.0)
+
+  # las$LOG$DT[1] == -999.25 == this las file's 'NULL' value
+  expect_equal(typeof(las$LOG$DT[1]), "double")
+  expect_true(is.na(las$LOG$DT[1]))
+
+  # Verify the another row starts correctly
+  expect_equal(las$LOG$DEPT[2], 909.875)
+})
+
+test_that("test v2.0 inf_uwi is '300E074350061450'", {
+  las_file <- "sample_2.0_inf_uwi.las"
+  test_path <- system.file("extdata", "2.0", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$WELL$VALUE[12], "300E074350061450")
+})
+
+test_that("test v2.0 inf_uwi with leading zero is '05001095820000'", {
+  las_file <- "sample_2.0_inf_uwi_leading_zero.las"
+  test_path <- system.file("extdata", "2.0", las_file, package = "lastools")
+  las <- read_las(test_path)
+  expect_equal(las$WELL$VALUE[12], "05001095820000")
+})
+
+test_that("test v2.0 inf_api with leading zero is '05001095820000'", {
+  las_file <- "sample_2.0_inf_api_leading_zero.las"
+  test_path <- system.file("extdata", "2.0", las_file, package = "lastools")
   las <- read_las(test_path)
   expect_equal(las$WELL$VALUE[12], "05001095820000")
 })


### PR DESCRIPTION
@Gitmaxwell ,

This change adopts an initial set of las v2.0 specific tests from lasio for reading las files: 
https://github.com/kinverarity1/lasio/tree/master/tests/examples/2.0

All the tests pass with no changes needed to the core lastools code.

Let me know if this change could be accepted (or rejected) or needs some additional changes before merging.

Thank you,

DC