### PR TITLE
Replace magic-quotes with regular double-quotes n the install command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Installation
 
 lastools can be installed from github repository using devtools:
 
-devtools::install\_github(“Gitmaxwell/lastools”)
+devtools::install\_github("Gitmaxwell/lastools")
 
 LAS Data
 --------


### PR DESCRIPTION
The `devtools::install\_github(“Gitmaxwell/lastools”)` instruction for lastools install contained magic-quotes that cause an error when cut-and-pasting the command to an `R>` terminal.  Replacing the magic-quotes with regular quotes enables the cut-and-paste to install lastools.  The related README.Rmd already has the correct double-quotes.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC